### PR TITLE
fix link to paper in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
             The single and combination tags present the deobfuscation results against one transformation and combined transformations, respectively.
           </li>
           <li>
-            Models are ranked according to overall score by default, which is an average of four metrics. More details about the metrics can be found in our <a href="https://xxx.xxxx.xxx/xxxx.xxx">paper</a>.
+            Models are ranked according to overall score by default, which is an average of four metrics. More details about the metrics can be found in our <a href="ccs2025a-JsDeObsBench.pdf">paper</a>.
           </li>
           <li>
             🎓 marks models designed for JavaScript deobfuscation, namely expert models, and the others are standard models.


### PR DESCRIPTION
- fixes https://github.com/jsdeobf/jsdeobf.github.io/issues/6

Currently the link to 'paper' on the leaderboard website links to the placeholder `https://xxx.xxxx.xxx/xxxx.xxx`:

https://github.com/jsdeobf/jsdeobf.github.io/blob/b8ee204dbae68bfd7663853df6340e792a212438/index.html#L145

This PR updates the link to the same paper linked from the top of the page:

- https://jsdeobf.github.io/ccs2025a-JsDeObsBench.pdf