### PR TITLE
improve links to benchmark repository and where to raise PRs with results

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
       <h3 class="fw-light text-nowrap mb-2">JsDeObsBench: Measuring and Benchmarking LLMs for JavaScript Deobfuscation</h3>
       <p class="authors text-nowrap">Guoqiang Chen, Xin Jin, Zhiqiang Lin</p>
     </div>
-    <p>📢 News: To submit new evaluation results, please create a pull request in the repository!</p>
+    <p>📢 News: To submit new evaluation results, please <a href="https://github.com/jsdeobf/jsdeobf.github.io/pulls">create a pull request</a> in the repository!</p>
     <div class="d-flex flex-row justify-content-center gap-3">
       <a href="https://github.com/jsdeobf/jsdeobf.github.io"><img
           src="https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white"
@@ -154,7 +154,7 @@
             Model providers have the responsibility to avoid data contamination. Models trained on close data can be affected by contamination.
           </li>
           <li>
-            Please use our benchmark repository to perform a new evaluation of your method and request to merge the results into this leaderboard.
+            Please use our <a href="https://github.com/Ch3nYe/JsDeObsBench">benchmark repository</a> to perform a new evaluation of your method and <a href="https://github.com/jsdeobf/jsdeobf.github.io/pulls">request to merge</a> the results into this leaderboard.
           </li>
         </ol>
       </div>


### PR DESCRIPTION
This PR adds a few links to the leaderboard website to:

- link to the benchmark repository
- link appropriate 'call to actions' for contributing results to the pull request section of the correct repository